### PR TITLE
Support Python 3.13 (bump pendulum/pydantic)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 argcomplete==2.0.0
 dsnparse==0.2.0
 Flask>=2.0.0
-pendulum==2.1.2
+pendulum>=3.0.0
 psutil>=5.9.0
-pydantic==2.5.*
+pydantic>=2.9,<3
 requests>=2.26.0
 rich==13.3.5
 tinydb>=4.7.0


### PR DESCRIPTION
## What
`pendulum==2.1.2` and `pydantic==2.5.*` have no cp313 wheels and fail to build on Python 3.13. This bumps them to versions that ship 3.13 wheels:

- `pendulum==2.1.2` → `pendulum>=3.0.0`
- `pydantic==2.5.*` → `pydantic>=2.9,<3`

## Why it's safe
- The code already uses the pydantic **v2** API (`field_validator`, `model_validator`, `json_schema_extra`), so 2.9+ is a drop-in.
- The pendulum usage in `PM3/model/process.py` (`pendulum.now() - from_timestamp(...)` → `.in_words()`, and `from_timestamp(...).astimezone().format(...)`) is unchanged across pendulum 3.

## Verification
Built and installed into a clean Python 3.13.5 venv (Debian 13): wheel builds, `pm3` / `pm3_backend` / `pm3_cron_checker` entry points run, `PM3.app`/`PM3.cli` import, and the pendulum/pydantic model code executes. Resolved to pendulum 3.2.0 / pydantic 2.13.4.